### PR TITLE
Lock license key row when selecting license keys for update.

### DIFF
--- a/app/models/spree/default_license_key_populator.rb
+++ b/app/models/spree/default_license_key_populator.rb
@@ -6,7 +6,7 @@ module Spree
       LicenseKey.available.where(
         :variant_id => inventory_unit.variant.id,
         :license_key_type_id => license_key_type.try(:id)
-      ).order('id asc').limit(quantity)
+      ).order('id asc').limit(quantity).lock
     end
 
     private


### PR DESCRIPTION
There are instances where two processes in parallel can try to get the same license keys. By locking the rows when selecting, we should be able to avoid this.
