### PR TITLE
Add activated_on column to save timestamp when license key was activated

### DIFF
--- a/app/models/spree/license_key.rb
+++ b/app/models/spree/license_key.rb
@@ -4,7 +4,7 @@ module Spree
     belongs_to :variant, :class_name => "Spree::Variant"
     belongs_to :license_key_type, :class_name => "Spree::LicenseKeyType"
 
-    attr_accessible :license_key, :inventory_unit_id, :variant_id, :void, :memo
+    attr_accessible :license_key, :inventory_unit_id, :variant_id, :void, :memo, :activated_on
 
     scope :available, where(inventory_unit_id: nil, void: false)
     scope :used, where('(inventory_unit_id IS NOT NULL) OR (void = ?)', true)

--- a/app/models/spree/license_key_populator.rb
+++ b/app/models/spree/license_key_populator.rb
@@ -25,7 +25,8 @@ module Spree
     private
 
     def self.assign_keys!(keys, inventory_unit)
-      keys.each { |key| key.update_attributes!(inventory_unit_id: inventory_unit.id) }
+      timestamp = DateTime.now
+      keys.each { |key| key.update_attributes!(inventory_unit_id: inventory_unit.id, activated_on: timestamp) }
     end
   end
 end

--- a/db/migrate/20140529001317_add_activated_on_to_spree_license_keys.rb
+++ b/db/migrate/20140529001317_add_activated_on_to_spree_license_keys.rb
@@ -1,0 +1,5 @@
+class AddActivatedOnToSpreeLicenseKeys < ActiveRecord::Migration
+  def change
+    add_column :spree_license_keys, :activated_on, :datetime
+  end
+end

--- a/spec/models/spree/license_key_populator_spec.rb
+++ b/spec/models/spree/license_key_populator_spec.rb
@@ -30,10 +30,10 @@ describe Spree::LicenseKeyPopulator do
           keys.each { |key| key.inventory_unit_id.should == inventory_unit.id }
         end
 
-        it "updates timestamps on license keys when they are assigned" do
+        it "sets activated_on on license keys when they are assigned" do
           t = Date.today + 5
           keys = Timecop.freeze(t) { populator_class.populate(inventory_unit, quantity) }
-          keys.each { |key| key.updated_at.should == t }
+          keys.each { |key| key.activated_on.should == t }
         end
 
         it "raises error for insufficient keys if none are available" do


### PR DESCRIPTION
Currently we're using `updated_at` for this purpose, but that can change if the license key is updated in other ways.
