### PR TITLE
Make Spree::Shipment#ship! asynchronous.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: ruby
-before_script: bundle exec rake test_app
+before_script:
+- bundle exec rake test_app
+- cd spec/dummy/
+- bundle exec rails g delayed_job:active_record
+- RAILS_ENV=test bundle exec rake db:migrate
+- cd ../..
 script: bundle exec rspec
 env:
 - DB=sqlite3

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -48,7 +48,7 @@ Spree::Order.class_eval do
 
   def after_finalize!
     electronic_shipments.each do |shipment|
-      shipment.ship! if shipment.can_ship?
+      shipment.delay.ship! if shipment.can_ship?
     end
   end
 

--- a/lib/spree_license_key.rb
+++ b/lib/spree_license_key.rb
@@ -1,2 +1,3 @@
 require 'spree_core'
+require 'delayed_job_active_record'
 require 'spree_license_key/engine'

--- a/spec/models/spree/payment_observer_spec.rb
+++ b/spec/models/spree/payment_observer_spec.rb
@@ -6,7 +6,7 @@ describe Spree::PaymentObserver do
     let(:payment) { build_stubbed :payment, :order => order}
     let(:order) { build_stubbed :order }
     let(:transition) { double StateMachine::Transition }
-    let(:shipment) { double Spree::Shipment }
+    let(:shipment) { build_stubbed :shipment }
 
     context "when transition is to shipped" do
       before do
@@ -20,6 +20,12 @@ describe Spree::PaymentObserver do
         it 'delivers the electronic item' do
           shipment.should_receive(:ship!).once
           observer.after_transition(payment, transition)
+        end
+
+        it 'creates a delayed job' do
+          Delayed::Worker.delay_jobs = true
+          expect { observer.after_transition(payment, transition) }.to change { Delayed::Job.count }.by(1)
+          Delayed::Worker.delay_jobs = false
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,9 @@ Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 require 'spree/core/testing_support/factories'
 require 'spree/core/url_helpers'
 
+# don't delay jobs if we are testing
+Delayed::Worker.delay_jobs = !Rails.env.test?
+
 RSpec.configure do |config|
   FactoryGirl.find_definitions
   config.include FactoryGirl::Syntax::Methods

--- a/spree_license_key.gemspec
+++ b/spree_license_key.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 1.3.0'
+  s.add_dependency 'delayed_job_active_record'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl', '~> 2.6.4'


### PR DESCRIPTION
By making the call to `ship!` asynchronous, delayed job takes over and will keep retrying even if it fails initially. This is important for handling cases where (for whatever reason) we have no more license keys or we cannot get more keys at the moment (e.g. a timeout error from an external API such as AVG).

The tests all pass, but this needs to be reviewed and discussed before merging.

Related to degica/basecamp2#42 and degica/extinguisher#33.
