### PR TITLE
Always check if a shipment can be shipped before shipping.

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -48,7 +48,7 @@ Spree::Order.class_eval do
 
   def after_finalize!
     electronic_shipments.each do |shipment|
-      shipment.delay.ship! if shipment.can_ship?
+      shipment.delay.asynchronous_ship! if shipment.can_ship?
     end
   end
 

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -15,6 +15,12 @@ Spree::Shipment.class_eval do
     end
   end
 
+  # Delayed jobs for asynchronous shipments should silently die if they cannot be shipped,
+  # e.g. in case they have been manually shipped since the last attempt.
+  def asynchronous_ship!
+    ship! if can_ship?
+  end
+
   # Modified from spree_core
   # This function is modified to ensure that inventory_units are only shipped
   # when they can be shipped

--- a/spec/models/spree/order_observer_spec.rb
+++ b/spec/models/spree/order_observer_spec.rb
@@ -18,7 +18,7 @@ describe Spree::OrderObserver do
         before { shipment.stub(:can_ship?) { true } }
 
         it 'delivers the electronic item' do
-          shipment.should_receive(:ship!).once
+          shipment.should_receive(:asynchronous_ship!).once
           observer.after_transition(order, transition)
         end
       end


### PR DESCRIPTION
This is needed to handle the case where a shipment is shipped manually or through some other means, and the delayed job tries to ship. In this case, we want the delayed job to stop, not start erroring on the state transition.
