### PR TITLE
Convert blank populator_type to default populator.

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -7,7 +7,7 @@ Spree::Variant.class_eval do
   validate :electronic_delivery_set
 
   def license_key_populator
-    populator_type.try(:constantize) || Spree::DefaultLicenseKeyPopulator
+    populator_type.present? ? populator_type.try(:constantize) : Spree::DefaultLicenseKeyPopulator
   end
 
   private

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe Spree::Variant do
+  let(:variant) { build :variant }
+
   describe '#valid?' do
-    let(:variant) { build :variant }
     subject { variant.valid? }
     context 'when electronic_delivery_keys > 0' do
       before do
@@ -20,6 +21,26 @@ describe Spree::Variant do
         end
         it { should be }
       end
+    end
+  end
+
+  describe 'license_key_populator' do
+    let(:variant) { build :variant }
+    subject { variant.license_key_populator }
+
+    context 'when populator type is blank' do
+      before { variant.populator_type = '' }
+      it { should == Spree::DefaultLicenseKeyPopulator }
+    end
+
+    context 'when populator type is nil' do
+      before { variant.populator_type = nil }
+      it { should == Spree::DefaultLicenseKeyPopulator }
+    end
+
+    context 'when populator type is another class' do
+      before { variant.populator_type = 'Spree' }
+      it { should == Spree }
     end
   end
 end


### PR DESCRIPTION
In forms we will be passing around blanks, which would be converted into "Ojbect" with the existing code. They should be convered to the default populator instead.
