### PR TITLE
Don't populate license keys if electronic delivery keys is zero.

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -9,4 +9,8 @@ Spree::InventoryUnit.class_eval do
   def populate_license_keys
     license_key_populator.populate(self, electronic_delivery_keys)
   end
+
+  def has_electronic_delivery_keys?
+    electronic_delivery_keys && electronic_delivery_keys > 0
+  end
 end

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -8,7 +8,7 @@ Spree::Shipment.class_eval do
 
   def electronic_delivery!
     inventory_units.each do |inventory_unit|
-      if inventory_unit.license_keys.empty? && inventory_unit.electronic_delivery_keys
+      if inventory_unit.license_keys.empty? && inventory_unit.has_electronic_delivery_keys?
         inventory_unit.populate_license_keys
         inventory_unit.reload
       end

--- a/spec/models/spree/shipment_decorator_spec.rb
+++ b/spec/models/spree/shipment_decorator_spec.rb
@@ -37,13 +37,21 @@ describe Spree::Shipment do
       shipment.electronic_delivery!
     end
 
-    context 'when electronic_delivery_keys is null' do
-      let(:number_of_keys_in_package) { nil }
-
+    shared_examples_for "inventory unit with no electronic delivery keys" do
       it "does not assign any license keys" do
         Spree::DefaultLicenseKeyPopulator.should_not_receive(:populate)
         shipment.electronic_delivery!
       end
+    end
+
+    context 'when electronic_delivery_keys is nil' do
+      let(:number_of_keys_in_package) { nil }
+      it_behaves_like "inventory unit with no electronic delivery keys"
+    end
+
+    context 'when electronic_delivery_keys is zero' do
+      let(:number_of_keys_in_package) { 0 }
+      it_behaves_like "inventory unit with no electronic delivery keys"
     end
 
     context 'multiple license keys' do


### PR DESCRIPTION
This is checking for nil, but we need to also check that it's not zero, otherwise we end up triggering callbacks for no reason.
