### PR TITLE
Fix create_shipment

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -29,9 +29,9 @@ Spree::InventoryUnit.class_eval do
     private
 
     # paraphrased from spree-core (create_units), with changes to assign
-    # inventory units to electronic shipment
+    # inventory units to electronic shipment or create new electronic shipment
     def create_electronic_units(order, variant, quantity)
-      shipment = order.shipments.electronic.first
+      shipment = order.shipments.electronic.first_or_create!
 
       quantity.times do
         order.inventory_units.create(

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -9,58 +9,30 @@ Spree::Order.class_eval do
     shipments.physical
   end
 
-  # from spree_core
-  def create_shipment!
-    shipping_method(true)
+  def create_shipment_with_electronic_delivery!
+    create_shipment_without_electronic_delivery!
 
-    if line_items.electronically_delivered.any? && electronic_shipments.empty?
-      create_shipment_for_shipping_method! Spree::ShippingMethod.electronic
+    # re-assign electronic inventory units to an electronic shipment
+    if line_items.electronically_delivered.any?
+      electronic_shipment = shipments.electronic.first_or_create!
+      electronic_shipment.inventory_units = inventory_units.electronically_delivered
     end
 
-    if line_items.physically_delivered.any?
-      if physical_shipments.empty?
-        create_shipment_for_shipping_method! shipping_method
-      else
-        physical_shipments.each do |physical_shipment|
-          if physical_shipment.shipping_method != shipping_method
-            physical_shipment.update_attributes!(:shipping_method => shipping_method)
-          end
-        end
-      end
-    end
-
-    if line_items.electronically_delivered.empty? && electronic_shipments.any?
-      electronic_shipments.destroy_all
-    end
-
+    # destroy any physical shipments without inventory units
     if line_items.physically_delivered.empty? && physical_shipments.any?
       physical_shipments.destroy_all
     end
 
-    if inventory_units.electronically_delivered.any?
-      electronic_shipments.first.inventory_units = inventory_units.electronically_delivered
-    end
-
-    if inventory_units.physically_delivered.any?
-      physical_shipments.first.inventory_units = inventory_units.physically_delivered
+    # destroy any electronic shipments without inventory units
+    if line_items.electronically_delivered.empty? && electronic_shipments.any?
+      electronic_shipments.destroy_all
     end
   end
+  alias_method_chain :create_shipment!, :electronic_delivery
 
   def after_finalize!
     electronic_shipments.each do |shipment|
       shipment.delay.asynchronous_ship! if shipment.can_ship?
     end
   end
-
-  private
-    def create_shipment_for_shipping_method!(method)
-      self.shipments << Spree::Shipment.create!(
-        {
-          :order => self,
-          :shipping_method => method,
-          :address => self.ship_address
-        },
-        :without_protection => true
-      )
-    end
 end

--- a/spec/factories/inventory_unit.rb
+++ b/spec/factories/inventory_unit.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :spree_inventory_unit, :class => 'Spree::InventoryUnit' do
-  end
-end

--- a/spec/factories/variant.rb
+++ b/spec/factories/variant.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :electronic_variant, parent: :variant do |v|
+    v.electronic_delivery_keys 1
+    v.electronic_delivery true
+  end
+end

--- a/spec/models/spree/inventory_decorator_spec.rb
+++ b/spec/models/spree/inventory_decorator_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe Spree::InventoryUnit do
+
+  describe ".increase" do
+    context "variant is electronic" do
+      let(:order) { create :order }
+      let(:electronic_variant) { create :electronic_variant }
+      let(:line_item) { create :line_item, variant: electronic_variant, order: order }
+      let!(:electronic_shipping_method) { create :shipping_method, name: Spree::ShippingMethod::electronic_delivery_name }
+      let!(:electronic_shipment) { create :shipment, order: order, shipping_method: electronic_shipping_method }
+      before { order.reload }
+
+      context "electronic shipment exists on order" do
+        it "creates an inventory unit" do
+          Spree::InventoryUnit.increase(order, electronic_variant, 5)
+          expect(order.inventory_units.first).to be_a(Spree::InventoryUnit)
+        end
+
+        it "assigns inventory unit to electronic shipment" do
+          Spree::InventoryUnit.increase(order, electronic_variant, 5)
+          expect(order.inventory_units.first.shipment).to eq(electronic_shipment)
+        end
+      end
+    end
+
+    # tests from spree-core, with minor modification to mocks
+    context "variant is physical" do
+      let(:variant) { mock_model(Spree::Variant, on_hand: 95, on_demand: false, electronic_delivery?: false) }
+      let(:line_item) { mock_model(Spree::LineItem, variant: variant, quantity: 5) }
+      let(:order) { mock_model(Spree::Order, line_items: [line_item], inventory_units: [], shipments: mock('shipments'), completed?: true) }
+      context "when :track_inventory_levels is true" do
+        before do
+          Spree::Config.set track_inventory_levels: true
+          Spree::InventoryUnit.stub(:create_units)
+        end
+
+        it "should decrement count_on_hand" do
+          variant.should_receive(:decrement!).with(:count_on_hand, 5)
+          Spree::InventoryUnit.increase(order, variant, 5)
+        end
+
+      end
+
+      context "when :track_inventory_levels is false" do
+        before do
+          Spree::Config.set track_inventory_levels: false
+          Spree::InventoryUnit.stub(:create_units)
+        end
+
+        it "should decrement count_on_hand" do
+          variant.should_not_receive(:decrement!)
+          Spree::InventoryUnit.increase(order, variant, 5)
+        end
+
+      end
+
+      context "when on_demand is true" do
+        before do
+          variant.stub(:on_demand).and_return(true)
+          Spree::InventoryUnit.stub(:create_units)
+        end
+
+        it "should decrement count_on_hand" do
+          variant.should_not_receive(:decrement!)
+          Spree::InventoryUnit.increase(order, variant, 5)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/models/spree/inventory_decorator_spec.rb
+++ b/spec/models/spree/inventory_decorator_spec.rb
@@ -10,10 +10,10 @@ describe Spree::InventoryUnit do
       let(:line_item) { create :line_item, variant: electronic_variant, order: order }
       let!(:electronic_shipping_method) { create :shipping_method, name: Spree::ShippingMethod::electronic_delivery_name }
       let!(:physical_shipment) { create :shipment, order: order }
-      let!(:electronic_shipment) { create :shipment, order: order, shipping_method: electronic_shipping_method }
       before { order.reload }
 
       context "electronic shipment exists on order" do
+        let!(:electronic_shipment) { create :shipment, order: order, shipping_method: electronic_shipping_method }
         it "creates new inventory units" do
           expect {
             Spree::InventoryUnit.increase(order, electronic_variant, 2)
@@ -28,6 +28,20 @@ describe Spree::InventoryUnit do
         it "assigns physical inventory units to physical shipment" do
           Spree::InventoryUnit.increase(order, physical_variant, 1)
           expect(order.inventory_units.first.shipment).to eq(physical_shipment)
+        end
+      end
+
+      context "no electronic shipment exists on order" do
+        it "creates new electronic shipment" do
+          expect {
+            Spree::InventoryUnit.increase(order, electronic_variant, 2)
+          }.to change { order.shipments.count }.from(1).to(2)
+        end
+
+        it "assigns inventory unit to new electronic shipment" do
+          Spree::InventoryUnit.increase(order, electronic_variant, 2)
+          shipment = order.inventory_units.first.shipment
+          expect(shipment).to be_electronic
         end
       end
     end

--- a/spec/models/spree/license_key_spec.rb
+++ b/spec/models/spree/license_key_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::LicenseKey do
-  let(:inventory_unit) { create :spree_inventory_unit }
+  let(:inventory_unit) { create :inventory_unit }
   let!(:available_license_key) { create :license_key }
   let!(:used_license_key) { create :license_key, inventory_unit: inventory_unit }
 

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -6,6 +6,9 @@ describe Spree::Order do
   let(:physical_variant) { create :variant }
   let!(:electronic_shipping_method) { create :shipping_method, :name => Spree::ShippingMethod::electronic_delivery_name }
   let!(:physical_shipping_method) { create :shipping_method }
+  before do
+    order.shipping_method = physical_shipping_method
+  end
 
   describe '.create_shipment!' do
     context "when there are electronic delivery items" do
@@ -24,9 +27,12 @@ describe Spree::Order do
       end
     end
 
-    context "when there are not electronic delivery items" do
+    context "when there are no electronic delivery items" do
       context "when there is an electronic shipment" do
         let!(:shipment) { create :shipment, :order => order, :shipping_method => electronic_shipping_method }
+        before do
+          order.shipping_method = electronic_shipping_method
+        end
 
         it "deletes the electronic shipment" do
           expect { order.create_shipment! }.to change{order.electronic_shipments.count}.from(1).to(0)
@@ -37,8 +43,6 @@ describe Spree::Order do
     context "when there are physical delivery items" do
       let!(:line_item) { create :line_item, :variant => physical_variant, :order => order }
       let!(:inventory_unit) { create :inventory_unit, :variant => physical_variant, :order => order }
-
-      before { order.shipping_method = physical_shipping_method }
 
       context "when there is not a physical shipment" do
         it 'adds a physical shipment' do

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::Order do
   let(:order) { create :order }
-  let(:electronic_variant) { create :variant, :electronic_delivery_keys => 1, :electronic_delivery => true }
+  let(:electronic_variant) { create :electronic_variant }
   let(:physical_variant) { create :variant }
   let!(:electronic_shipping_method) { create :shipping_method, :name => Spree::ShippingMethod::electronic_delivery_name }
   let!(:physical_shipping_method) { create :shipping_method }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,4 +58,8 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  # focus!
+  config.run_all_when_everything_filtered = true
+  config.filter_run focus: true
 end


### PR DESCRIPTION
The create_shipment! method does not work if a store has both physical and electronic shipments, because create_units can be called *after* a shipment has already been created. This is an attempt to fix that issue by moving some of the logic from that method to `Spree::InventoryUnit#increase`, where it would seem to belong.