### PR TITLE
Send license key email asynchronously.

### DIFF
--- a/app/mailers/spree/email_delivery_mailer.rb
+++ b/app/mailers/spree/email_delivery_mailer.rb
@@ -3,4 +3,6 @@ class Spree::EmailDeliveryMailer < ActionMailer::Base
     @inventory_units = shipment.inventory_units
     mail :to => shipment.order.user.email
   end
+
+  handle_asynchronously :electronic_delivery_email
 end


### PR DESCRIPTION
We need to send emails asynchronously so that in case something,
the mailer will keep trying to send the email.