### PR TITLE
Revert "Send license key email asynchronously."

### DIFF
--- a/app/mailers/spree/email_delivery_mailer.rb
+++ b/app/mailers/spree/email_delivery_mailer.rb
@@ -3,6 +3,4 @@ class Spree::EmailDeliveryMailer < ActionMailer::Base
     @inventory_units = shipment.inventory_units
     mail :to => shipment.order.user.email
   end
-
-  handle_asynchronously :electronic_delivery_email
 end


### PR DESCRIPTION
This reverts commit 5c27d5745aa9df94bcf9071df197076599e144db.

We added this after we had issues with sendgrid that caused delayed jobs to fail and re-send license keys, but the commit does not actually work: it makes email_delivery_email asynchronous so it returns `nil`, and then `deliver` is called on that and fails. Luckily we override this method so it doesn't seem to have affected anything.