### PR TITLE
Scopes for license keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Be sure to bundle your dependencies and then create a dummy test app for the spe
 
     $ bundle
     $ bundle exec rake test_app
-    $ bundle exec rspec spec
+    $ cd spec/dummy/
+    $ bundle exec rails g delayed_job:active_record
+    $ RAILS_ENV=test bundle exec rake db:migrate
+    $ cd ../..
+    $ bundle exec rspec
 
 Copyright (c) 2012 [name of extension creator], released under the New BSD License

--- a/app/models/spree/license_key.rb
+++ b/app/models/spree/license_key.rb
@@ -7,6 +7,7 @@ module Spree
     attr_accessible :license_key, :inventory_unit_id, :variant_id, :void, :memo, :activated_on
 
     scope :available, where(inventory_unit_id: nil, void: false)
-    scope :used, where('(inventory_unit_id IS NOT NULL) OR (void = ?)', true)
+    scope :void, where(void: true)
+    scope :used, where('inventory_unit_id IS NOT NULL')
   end
 end

--- a/app/models/spree/license_key.rb
+++ b/app/models/spree/license_key.rb
@@ -7,7 +7,15 @@ module Spree
     attr_accessible :license_key, :inventory_unit_id, :variant_id, :void, :memo, :activated_on
 
     scope :available, where(inventory_unit_id: nil, void: false)
-    scope :void, where(void: true)
     scope :used, where('inventory_unit_id IS NOT NULL')
+    scope :void, where(void: true)
+
+    def used?
+      self.class.used.where(id: id).any?
+    end
+
+    def available?
+      self.class.available.where(id: id).any?
+    end
   end
 end

--- a/app/models/spree/license_key.rb
+++ b/app/models/spree/license_key.rb
@@ -11,11 +11,11 @@ module Spree
     scope :void, where(void: true)
 
     def used?
-      self.class.used.where(id: id).any?
+      inventory_unit.present?
     end
 
     def available?
-      self.class.available.where(id: id).any?
+      !void? && inventory_unit.nil?
     end
   end
 end

--- a/spec/models/spree/license_key_spec.rb
+++ b/spec/models/spree/license_key_spec.rb
@@ -9,12 +9,18 @@ describe Spree::LicenseKey do
   describe '.available' do
     it 'returns license keys which do not have inventory units' do
       Spree::LicenseKey.available.all.should == [ available_license_key ]
+      expect(available_license_key.available?).to eq true
+      expect(used_license_key.available?).to      eq false
+      expect(voided_license_key.available?).to    eq false
     end
   end
 
   describe '.used' do
     it 'returns license keys which have inventory units' do
       Spree::LicenseKey.used.all.should == [ used_license_key ]
+      expect(available_license_key.used?).to eq false
+      expect(used_license_key.used?).to      eq true
+      expect(voided_license_key.used?).to    eq false
     end
   end
 

--- a/spec/models/spree/license_key_spec.rb
+++ b/spec/models/spree/license_key_spec.rb
@@ -4,14 +4,10 @@ describe Spree::LicenseKey do
   let(:inventory_unit) { create :inventory_unit }
   let!(:available_license_key) { create :license_key }
   let!(:used_license_key) { create :license_key, inventory_unit: inventory_unit }
+  let!(:voided_license_key) { create :license_key, void: true }
 
   describe '.available' do
     it 'returns license keys which do not have inventory units' do
-      Spree::LicenseKey.available.all.should == [ available_license_key ]
-    end
-
-    it 'does not return void license keys' do
-      create :license_key, void: true
       Spree::LicenseKey.available.all.should == [ available_license_key ]
     end
   end
@@ -20,10 +16,11 @@ describe Spree::LicenseKey do
     it 'returns license keys which have inventory units' do
       Spree::LicenseKey.used.all.should == [ used_license_key ]
     end
+  end
 
-    it 'returns license keys which are void' do
-      void_license_key = create :license_key, void: true
-      Spree::LicenseKey.used.should include void_license_key
+  describe '.void' do
+    it 'returns license keys which have are voided' do
+      Spree::LicenseKey.void.all.should == [ voided_license_key ]
     end
   end
 end


### PR DESCRIPTION
The `used` scope name is not ideal if it also includes keys that are `void`.  I have separated this into two ideas:  `used` for when it has been given to a user within an order, and `void` for when the key has been cancelled by hand in basecamp.

The only part of basecamp this should affect is https://github.com/degica/basecamp2/blob/master/app/views/basecamp_spree/license_keys/index.html.erb#L14, which I don't think should matter.

However these methods will be useful for my upcoming PR I am working on that involves importing of keys.  There I want to handle import of void, used, and available keys differently, so these are handy to have.