### PR TITLE
Refactor populator methods into instance methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 - DB=sqlite3
 - DB=mysql
 rvm:
-- 1.9.3
+- 2.1.7
 notifications:
   hipchat:
     rooms:

--- a/Guardfile
+++ b/Guardfile
@@ -8,7 +8,7 @@ notification :tmux,
   :line_separator => ' > ', # since we are single line we need a separator
   :color_location => 'status-left-bg' # to customize which tmux element will change color'
 
-guard 'rspec' do
+guard 'rspec', cmd: "bundle exec rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }

--- a/app/models/spree/default_license_key_populator.rb
+++ b/app/models/spree/default_license_key_populator.rb
@@ -1,7 +1,7 @@
 module Spree
   class DefaultLicenseKeyPopulator < LicenseKeyPopulator
 
-    def self.get_available_keys(inventory_unit, quantity, license_key_type=nil)
+    def get_available_keys(inventory_unit, quantity, license_key_type=nil)
       return false unless count_available(inventory_unit, license_key_type) >= quantity
       LicenseKey.available.where(
         :variant_id => inventory_unit.variant.id,
@@ -9,14 +9,14 @@ module Spree
       ).order('id asc').limit(quantity).lock
     end
 
-    def self.failure(inventory_unit, license_key_type)
+    def failure(inventory_unit, license_key_type)
       raise(InsufficientLicenseKeys,
             "Variant: #{inventory_unit.variant.to_param}, License Key Type: #{license_key_type.try(:id)}")
     end
 
     private
 
-    def self.count_available(inventory_unit, license_key_type)
+    def count_available(inventory_unit, license_key_type)
       relation = license_key_type ? license_key_type.available : Spree::LicenseKey.available.where(license_key_type_id: nil)
       relation.where(variant_id: inventory_unit.variant.try(:id)).count
     end

--- a/app/models/spree/license_key_populator.rb
+++ b/app/models/spree/license_key_populator.rb
@@ -1,9 +1,17 @@
 module Spree
   class LicenseKeyPopulator
-    def self.populate(inventory_unit, quantity)
+    attr_reader :variant
+
+    def initialize(variant)
+      @variant = variant
+    end
+
+    def license_key_types
+      variant.license_key_types.empty? ? [nil] : variant.license_key_types
+    end
+
+    def populate(inventory_unit, quantity)
       ActiveRecord::Base.transaction do
-        variant = inventory_unit.variant
-        license_key_types = variant.license_key_types.empty? ? [nil] : variant.license_key_types
         license_key_types.each do |license_key_type|
           if keys = get_available_keys(inventory_unit, quantity, license_key_type)
             success(inventory_unit, license_key_type)
@@ -17,21 +25,21 @@ module Spree
     end
 
     # Gets keys from source. Should return a relation.
-    def self.get_available_keys(inventory_unit, quantity, license_key_type=nil)
+    def get_available_keys(inventory_unit, quantity, license_key_type=nil)
       raise NotImplementedError, "Spree::LicenseKeyPopulator must implement a get_available_keys method."
     end
 
-    def self.failure(inventory_unit, license_key_type)
+    def failure(inventory_unit, license_key_type)
     end
 
-    def self.success(inventory_unit, license_key_type)
+    def success(inventory_unit, license_key_type)
     end
 
     class InsufficientLicenseKeys < ::StandardError; end
 
     private
 
-    def self.assign_keys!(keys, inventory_unit)
+    def assign_keys!(keys, inventory_unit)
       timestamp = DateTime.now
       keys.each { |key| key.update_attributes!(inventory_unit_id: inventory_unit.id, activated_on: timestamp) }
     end

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -12,6 +12,6 @@ Spree::ShippingMethod.class_eval do
   end
 
   def self.electronic
-    self.where(:name => ELECTRONIC_DELIVERY_NAME).first!
+    where(:name => ELECTRONIC_DELIVERY_NAME).first!
   end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -6,8 +6,12 @@ Spree::Variant.class_eval do
 
   validate :electronic_delivery_set
 
-  def license_key_populator
+  def license_key_populator_class
     populator_type.present? ? populator_type.try(:constantize) : Spree::DefaultLicenseKeyPopulator
+  end
+
+  def license_key_populator
+    license_key_populator_class.new(self)
   end
 
   private

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -16,7 +16,7 @@ Spree::Variant.class_eval do
 
   private
   def electronic_delivery_set
-    if self.electronic_delivery_keys && self.electronic_delivery_keys > 0 && !self.electronic_delivery?
+    if electronic_delivery_keys && electronic_delivery_keys > 0 && !electronic_delivery?
       errors.add(:electronic_delivery, I18n.t('spree.variant.electronic_delivery_setting_error'))
     end
   end

--- a/spec/models/spree/default_license_key_populator_spec.rb
+++ b/spec/models/spree/default_license_key_populator_spec.rb
@@ -4,12 +4,13 @@ describe Spree::DefaultLicenseKeyPopulator do
   let(:inventory_unit) { build_stubbed :inventory_unit, variant: variant }
   let(:variant) { nil }
   let(:quantity) { 2 }
+  let(:populator) { described_class.new(variant) }
 
   describe '.get_available_keys' do
     shared_examples_for "license key populator" do
       context "no keys available" do
         it "returns false" do
-          described_class.get_available_keys(inventory_unit, quantity, license_key_type).should == false
+          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == false
         end
       end
 
@@ -18,25 +19,25 @@ describe Spree::DefaultLicenseKeyPopulator do
         let!(:license_keys) { quantity.times.map { create(:license_key, variant: variant, license_key_type: license_key_type) } }
 
         it "returns license keys with this type" do
-          described_class.get_available_keys(inventory_unit, quantity, license_key_type).should == license_keys
+          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == license_keys
         end
 
         it "only returns license keys with this type" do
           other_license_key_type = create :license_key_type
           other_license_keys = quantity.times.map { create :license_key, variant: variant, license_key_type: other_license_key_type }
-          described_class.get_available_keys(inventory_unit, quantity, other_license_key_type).should == other_license_keys
+          populator.get_available_keys(inventory_unit, quantity, other_license_key_type).should == other_license_keys
         end
 
         it "only returns license keys without inventory ids" do
           license_keys.each { |key| key.update_attributes!(inventory_unit_id: inventory_unit.id) }
           other_license_keys = quantity.times.map { create :license_key, variant: variant, license_key_type: license_key_type }
-          described_class.get_available_keys(inventory_unit, quantity, license_key_type).should == other_license_keys
+          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == other_license_keys
         end
 
         it "only returns license keys that are not void" do
           license_keys.each { |key| key.update_attributes!(void: true) }
           other_license_keys = quantity.times.map { create :license_key, variant: variant, license_key_type: license_key_type }
-          described_class.get_available_keys(inventory_unit, quantity, license_key_type).should == other_license_keys
+          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == other_license_keys
         end
       end
     end
@@ -55,7 +56,7 @@ describe Spree::DefaultLicenseKeyPopulator do
   describe 'failure callback' do
     let(:variant) { build_stubbed :variant }
     it "raises error for insufficient keys if none are available" do
-      expect { described_class.populate(inventory_unit, quantity + 1) }.to raise_error(Spree::LicenseKeyPopulator::InsufficientLicenseKeys)
+      expect { populator.populate(inventory_unit, quantity + 1) }.to raise_error(Spree::LicenseKeyPopulator::InsufficientLicenseKeys)
     end
   end
 end

--- a/spec/models/spree/shipment_decorator_spec.rb
+++ b/spec/models/spree/shipment_decorator_spec.rb
@@ -33,13 +33,13 @@ describe Spree::Shipment do
     end
 
     it 'allocates the next license key to the inventory unit' do
-      Spree::DefaultLicenseKeyPopulator.should_receive(:populate).once.with(inventory_unit, 1)
+      expect_any_instance_of(Spree::DefaultLicenseKeyPopulator).to receive(:populate).once.with(inventory_unit, 1)
       shipment.electronic_delivery!
     end
 
     shared_examples_for "inventory unit with no electronic delivery keys" do
       it "does not assign any license keys" do
-        Spree::DefaultLicenseKeyPopulator.should_not_receive(:populate)
+        expect_any_instance_of(Spree::DefaultLicenseKeyPopulator).not_to receive(:populate)
         shipment.electronic_delivery!
       end
     end
@@ -58,7 +58,7 @@ describe Spree::Shipment do
       let(:number_of_keys_in_package) { 2 }
 
       it 'allocates keys to match the number of keys in the package' do
-        Spree::DefaultLicenseKeyPopulator.should_receive(:populate).once.with(inventory_unit, 2)
+        Spree::DefaultLicenseKeyPopulator.any_instance.should_receive(:populate).once.with(inventory_unit, 2)
         shipment.electronic_delivery!
       end
     end
@@ -108,7 +108,7 @@ describe Spree::Shipment do
         before { shipment.inventory_units << inventory_unit }
 
         it "sends an e-mail shipment mailer" do
-          Spree::EmailDeliveryMailer.any_instance.should_receive(:electronic_delivery_email).once
+          expect_any_instance_of(Spree::EmailDeliveryMailer).to receive(:electronic_delivery_email).once
           shipment.send_shipped_email
         end
 
@@ -119,7 +119,7 @@ describe Spree::Shipment do
       let(:electronic) { false }
 
       it "sends a physical shipment mailer" do
-        Spree::ShipmentMailer.any_instance.should_receive(:shipped_email).once
+        expect_any_instance_of(Spree::ShipmentMailer).to receive(:shipped_email).once
         shipment.send_shipped_email
       end
     end

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+class MyPopulator < Spree::LicenseKeyPopulator; end
+
 describe Spree::Variant do
   let(:variant) { build :variant }
 
@@ -30,17 +32,20 @@ describe Spree::Variant do
 
     context 'when populator type is blank' do
       before { variant.populator_type = '' }
-      it { should == Spree::DefaultLicenseKeyPopulator }
+      it { should be_a(Spree::DefaultLicenseKeyPopulator) }
+      its(:variant) { should == variant }
     end
 
     context 'when populator type is nil' do
       before { variant.populator_type = nil }
-      it { should == Spree::DefaultLicenseKeyPopulator }
+      it { should be_a(Spree::DefaultLicenseKeyPopulator) }
+      its(:variant) { should == variant }
     end
 
     context 'when populator type is another class' do
-      before { variant.populator_type = 'Spree' }
-      it { should == Spree }
+      before { variant.populator_type = 'MyPopulator' }
+      it { should be_a(MyPopulator) }
+      its(:variant) { should == variant }
     end
   end
 end

--- a/spree_license_key.gemspec
+++ b/spree_license_key.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.9'
   if ENV['DB'] == 'mysql'
-    s.add_development_dependency 'mysql2'
+    s.add_development_dependency 'mysql2', '~> 0.3.10'
   else
     s.add_development_dependency 'sqlite3'
   end


### PR DESCRIPTION
Currently the populator class is just used as a place to store a bunch of class methods, but it really should be an instance which is iniated with a variant. This adds a few lines of code but I think makes more sense.