### PR TITLE
Refactor out inventory unit.

### DIFF
--- a/app/models/spree/default_license_key_populator.rb
+++ b/app/models/spree/default_license_key_populator.rb
@@ -1,24 +1,24 @@
 module Spree
   class DefaultLicenseKeyPopulator < LicenseKeyPopulator
 
-    def get_available_keys(inventory_unit, quantity, license_key_type=nil)
-      return false unless count_available(inventory_unit, license_key_type) >= quantity
+    def get_available_keys(quantity, license_key_type=nil)
+      return false unless count_available(license_key_type) >= quantity
       LicenseKey.available.where(
-        :variant_id => inventory_unit.variant.id,
+        :variant_id => variant.id,
         :license_key_type_id => license_key_type.try(:id)
       ).order('id asc').limit(quantity).lock
     end
 
     def failure(inventory_unit, license_key_type)
       raise(InsufficientLicenseKeys,
-            "Variant: #{inventory_unit.variant.to_param}, License Key Type: #{license_key_type.try(:id)}")
+            "Variant: #{variant.to_param}, License Key Type: #{license_key_type.try(:id)}")
     end
 
     private
 
-    def count_available(inventory_unit, license_key_type)
+    def count_available(license_key_type)
       relation = license_key_type ? license_key_type.available : Spree::LicenseKey.available.where(license_key_type_id: nil)
-      relation.where(variant_id: inventory_unit.variant.try(:id)).count
+      relation.where(variant_id: variant.try(:id)).count
     end
   end
 end

--- a/app/models/spree/license_key_populator.rb
+++ b/app/models/spree/license_key_populator.rb
@@ -13,7 +13,7 @@ module Spree
     def populate(inventory_unit, quantity)
       ActiveRecord::Base.transaction do
         license_key_types.each do |license_key_type|
-          if keys = get_available_keys(inventory_unit, quantity, license_key_type)
+          if keys = get_available_keys(quantity, license_key_type)
             success(inventory_unit, license_key_type)
             assign_keys!(keys, inventory_unit)
           else
@@ -25,7 +25,7 @@ module Spree
     end
 
     # Gets keys from source. Should return a relation.
-    def get_available_keys(inventory_unit, quantity, license_key_type=nil)
+    def get_available_keys(quantity, license_key_type=nil)
       raise NotImplementedError, "Spree::LicenseKeyPopulator must implement a get_available_keys method."
     end
 

--- a/spec/models/spree/default_license_key_populator_spec.rb
+++ b/spec/models/spree/default_license_key_populator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::DefaultLicenseKeyPopulator do
-  let(:inventory_unit) { build_stubbed :inventory_unit, variant: variant }
+  let(:inventory_unit) { build_stubbed(:inventory_unit) }
   let(:variant) { nil }
   let(:quantity) { 2 }
   let(:populator) { described_class.new(variant) }
@@ -10,7 +10,7 @@ describe Spree::DefaultLicenseKeyPopulator do
     shared_examples_for "license key populator" do
       context "no keys available" do
         it "returns false" do
-          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == false
+          populator.get_available_keys(quantity, license_key_type).should == false
         end
       end
 
@@ -19,25 +19,25 @@ describe Spree::DefaultLicenseKeyPopulator do
         let!(:license_keys) { quantity.times.map { create(:license_key, variant: variant, license_key_type: license_key_type) } }
 
         it "returns license keys with this type" do
-          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == license_keys
+          populator.get_available_keys(quantity, license_key_type).should == license_keys
         end
 
         it "only returns license keys with this type" do
           other_license_key_type = create :license_key_type
           other_license_keys = quantity.times.map { create :license_key, variant: variant, license_key_type: other_license_key_type }
-          populator.get_available_keys(inventory_unit, quantity, other_license_key_type).should == other_license_keys
+          populator.get_available_keys(quantity, other_license_key_type).should == other_license_keys
         end
 
         it "only returns license keys without inventory ids" do
           license_keys.each { |key| key.update_attributes!(inventory_unit_id: inventory_unit.id) }
           other_license_keys = quantity.times.map { create :license_key, variant: variant, license_key_type: license_key_type }
-          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == other_license_keys
+          populator.get_available_keys(quantity, license_key_type).should == other_license_keys
         end
 
         it "only returns license keys that are not void" do
           license_keys.each { |key| key.update_attributes!(void: true) }
           other_license_keys = quantity.times.map { create :license_key, variant: variant, license_key_type: license_key_type }
-          populator.get_available_keys(inventory_unit, quantity, license_key_type).should == other_license_keys
+          populator.get_available_keys(quantity, license_key_type).should == other_license_keys
         end
       end
     end

--- a/spec/models/spree/license_key_populator_spec.rb
+++ b/spec/models/spree/license_key_populator_spec.rb
@@ -12,7 +12,7 @@ describe Spree::LicenseKeyPopulator do
       it "raises NotImplementedError" do
         populator = Spree::LicenseKeyPopulator.new(variant)
         expect {
-          populator.get_available_keys(inventory_unit, quantity)
+          populator.get_available_keys(quantity)
         }.to raise_error(NotImplementedError)
       end
     end
@@ -22,8 +22,8 @@ describe Spree::LicenseKeyPopulator do
       let(:populator_class) do
         Class.new(Spree::LicenseKeyPopulator) do
           # Minimal populator function, returns false if there are not enough keys.
-          def get_available_keys(inventory_unit, quantity, license_key_type=nil)
-            quantity <= Spree::LicenseKey.count ?  Spree::LicenseKey.scoped : false
+          def get_available_keys(quantity, license_key_type=nil)
+            quantity <= Spree::LicenseKey.count ? Spree::LicenseKey.scoped : false
           end
         end
       end
@@ -74,7 +74,7 @@ describe Spree::LicenseKeyPopulator do
         it_behaves_like "license key populator"
 
         it "calls get_available_keys once with nil license_key_type" do
-          populator.should_receive(:get_available_keys).once.with(inventory_unit, quantity, nil).and_call_original
+          populator.should_receive(:get_available_keys).once.with(quantity, nil).and_call_original
           populator.populate(inventory_unit, quantity)
         end
       end
@@ -92,8 +92,8 @@ describe Spree::LicenseKeyPopulator do
         end
 
         it "calls get_available_keys once for each license key type" do
-          populator.should_receive(:get_available_keys).once.with(inventory_unit, quantity, license_key_type_1).and_call_original
-          populator.should_receive(:get_available_keys).once.with(inventory_unit, quantity, license_key_type_2).and_call_original
+          populator.should_receive(:get_available_keys).once.with(quantity, license_key_type_1).and_call_original
+          populator.should_receive(:get_available_keys).once.with(quantity, license_key_type_2).and_call_original
           populator.populate(inventory_unit, quantity)
         end
       end


### PR DESCRIPTION
Most of the time we don't need to actually reference the inventory unit, just the variant is enough.