### PR TITLE
Fix error when track_inventory_levels true

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -31,13 +31,13 @@ Spree::InventoryUnit.class_eval do
     # paraphrased from spree-core (create_units), with changes to assign
     # inventory units to electronic shipment or create new electronic shipment
     def create_electronic_units(order, variant, quantity)
-      shipment = order.shipments.electronic.first_or_create!
-
-      quantity.times do
-        order.inventory_units.create(
-          { variant: variant, state: "sold", shipment: shipment },
-          without_protection: true)
+      inventory_units = quantity.times.map do
+        order.inventory_units.create( { variant: variant, state: "sold" }, without_protection: true)
       end
+
+      shipment = order.shipments.electronic.first_or_initialize
+      shipment.inventory_units = inventory_units
+      shipment.save!
     end
   end
 end


### PR DESCRIPTION
`Spree::Shipment`'s `inventory_units` relation needs to have one `inventory_units` when `track_inventory_levels` true and [some conditions](https://github.com/degica/spree/blob/1-3-rebased-no-api/core/app/models/spree/shipment.rb#L145-L148).

We need to change logic. 
we need to create `inventory units` first,  Then need to create `shipment`.

see. https://github.com/degica/spree/blob/1-3-rebased-no-api/core/app/models/spree/shipment.rb#L24