### PR TITLE
Fix error when track_inventory_levels true

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -31,13 +31,13 @@ Spree::InventoryUnit.class_eval do
     # paraphrased from spree-core (create_units), with changes to assign
     # inventory units to electronic shipment or create new electronic shipment
     def create_electronic_units(order, variant, quantity)
-      shipment = order.shipments.electronic.first_or_create!
-
-      quantity.times do
-        order.inventory_units.create(
-          { variant: variant, state: "sold", shipment: shipment },
-          without_protection: true)
+      inventory_units = quantity.times.map do
+        order.inventory_units.create( { variant: variant, state: "sold" }, without_protection: true)
       end
+
+      shipment = order.shipments.electronic.first_or_initialize
+      shipment.inventory_units << inventory_units
+      shipment.save!
     end
   end
 end

--- a/spec/models/spree/inventory_unit_decorator_spec.rb
+++ b/spec/models/spree/inventory_unit_decorator_spec.rb
@@ -47,8 +47,7 @@ describe Spree::InventoryUnit do
 
       context "when calls couple times" do
         it "creates related elctronic shipment couple inventory units" do
-          Spree::InventoryUnit.increase(order, electronic_variant, 1)
-          Spree::InventoryUnit.increase(order, electronic_variant, 1)
+          2.times { Spree::InventoryUnit.increase(order, electronic_variant, 1) }
 
           expect(order.shipments.electronic.first.inventory_units.count).to be(2)
         end

--- a/spec/models/spree/inventory_unit_decorator_spec.rb
+++ b/spec/models/spree/inventory_unit_decorator_spec.rb
@@ -44,6 +44,15 @@ describe Spree::InventoryUnit do
           expect(shipment).to be_electronic
         end
       end
+
+      context "when calls couple times" do
+        it "creates related elctronic shipment couple inventory units" do
+          Spree::InventoryUnit.increase(order, electronic_variant, 1)
+          Spree::InventoryUnit.increase(order, electronic_variant, 1)
+
+          expect(order.shipments.electronic.first.inventory_units.count).to be(2)
+        end
+      end
     end
 
     # tests from spree-core, with minor modification to mocks


### PR DESCRIPTION
Related https://github.com/degica/spree-license-key/pull/22
(It had a bug. But this PR will fix that)

`Spree::Shipment`'s `inventory_units` relation needs to have one
`inventory_units` when `track_inventory_levels` true and [some
conditions](https://github.com/degica/spree/blob/1-3-rebased-no-api/core/app/models/spree/shipment.rb#L145-L148).

We need to change logic.
We need to create `inventory units` first,  Then need to create
`shipment`.

See.
https://github.com/degica/spree/blob/1-3-rebased-no-api/core/app/models/spree/shipment.rb#L24