### PR TITLE
on_hand for electronic variants

### DIFF
--- a/app/models/spree/default_license_key_populator.rb
+++ b/app/models/spree/default_license_key_populator.rb
@@ -14,6 +14,10 @@ module Spree
             "Variant: #{inventory_unit.variant.to_param}, License Key Type: #{license_key_type.try(:id)}")
     end
 
+    def on_hand
+      license_key_types.map { |type| count_available(type) }.min
+    end
+
     private
 
     def count_available(license_key_type)

--- a/app/models/spree/infinite_license_key_populator.rb
+++ b/app/models/spree/infinite_license_key_populator.rb
@@ -1,0 +1,7 @@
+module Spree
+  class InfiniteLicenseKeyPopulator < DefaultLicenseKeyPopulator
+    def on_hand
+      Float::INFINITY
+    end
+  end
+end

--- a/app/models/spree/license_key_populator.rb
+++ b/app/models/spree/license_key_populator.rb
@@ -35,6 +35,11 @@ module Spree
     def success(inventory_unit, license_key_type)
     end
 
+    # default to true
+    def on_hand
+      true
+    end
+
     class InsufficientLicenseKeys < ::StandardError; end
 
     private

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -14,6 +14,15 @@ Spree::Variant.class_eval do
     license_key_populator_class.new(self)
   end
 
+  def on_hand_with_electronic_delivery
+    if electronic_delivery?
+      license_key_populator.on_hand
+    else
+      on_hand_without_electronic_delivery
+    end
+  end
+  alias_method_chain :on_hand, :electronic_delivery
+
   private
   def electronic_delivery_set
     if electronic_delivery_keys && electronic_delivery_keys > 0 && !electronic_delivery?

--- a/spec/models/spree/default_license_key_populator_spec.rb
+++ b/spec/models/spree/default_license_key_populator_spec.rb
@@ -6,7 +6,7 @@ describe Spree::DefaultLicenseKeyPopulator do
   let(:quantity) { 2 }
   let(:populator) { described_class.new(variant) }
 
-  describe '.get_available_keys' do
+  describe '#get_available_keys' do
     shared_examples_for "license key populator" do
       context "no keys available" do
         it "returns false" do
@@ -57,6 +57,36 @@ describe Spree::DefaultLicenseKeyPopulator do
     let(:variant) { build_stubbed :variant }
     it "raises error for insufficient keys if none are available" do
       expect { populator.populate(inventory_unit, quantity + 1) }.to raise_error(Spree::LicenseKeyPopulator::InsufficientLicenseKeys)
+    end
+  end
+
+  describe '#on_hand' do
+    let(:variant) { create :variant }
+    let!(:license_keys) do
+    end
+
+    context "nil license key type" do
+      before do
+        quantity.times.map { create(:license_key, variant: variant, license_key_type: nil) }
+      end
+
+      it "returns number of remaining keys" do
+        expect(populator.on_hand).to eq(2)
+      end
+    end
+
+    context "license key types defined" do
+      let(:license_key_type) { create(:license_key_type) }
+      before do
+        license_key_type_1 = create(:license_key_type, variants: [variant])
+        create(:license_key, variant: variant, license_key_type: license_key_type_1)
+        license_key_type_2 = create(:license_key_type, variants: [variant])
+        2.times { create(:license_key, variant: variant, license_key_type: license_key_type_2) }
+      end
+
+      it "returns minimum number of remaining keys across all types" do
+        expect(populator.on_hand).to eq(1)
+      end
     end
   end
 end

--- a/spec/models/spree/infinite_license_key_populator_spec.rb
+++ b/spec/models/spree/infinite_license_key_populator_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Spree::InfiniteLicenseKeyPopulator do
+  describe "#on_hand" do
+    let(:populator) { described_class.new(stub_model(Spree::Variant)) }
+    it "always returns infinity" do
+      expect(populator.on_hand).to eq(Float::INFINITY)
+    end
+  end
+end

--- a/spec/models/spree/license_key_populator_spec.rb
+++ b/spec/models/spree/license_key_populator_spec.rb
@@ -98,5 +98,11 @@ describe Spree::LicenseKeyPopulator do
         end
       end
     end
+
+    describe '#on_hand' do
+      it 'returns true' do
+        expect(license_key_populator.on_hand).to eq(true)
+      end
+    end
   end
 end

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -48,4 +48,30 @@ describe Spree::Variant do
       its(:variant) { should == variant }
     end
   end
+
+  describe 'on_hand' do
+    let(:variant) do
+      build_stubbed :variant, on_hand: 5, electronic_delivery: electronic_delivery
+    end
+
+    context 'physical delivery' do
+      let(:electronic_delivery) { false }
+      it 'returns number on hand' do
+        expect(variant.on_hand).to eq(5)
+      end
+    end
+
+    context 'electronic delivery' do
+      let(:electronic_delivery) { true }
+      before do
+        variant.stub(:license_key_populator) do
+          double("license key populator", on_hand: 10)
+        end
+      end
+
+      it 'returns number on hand according to populator' do
+        expect(variant.on_hand).to eq(10)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This overrides the default `on_hand` method of `Spree::Variant` to return the number of keys available for electronically delivered variants (otherwise it defaults to the attribute value). This allows us to check the number of keys in the database and use that to e.g. stop a customer from putting an item into the cart if there are no keys left.