### PR TITLE
Fix stack level too deep

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -14,14 +14,14 @@ Spree::Variant.class_eval do
     license_key_populator_class.new(self)
   end
 
-  def on_hand_with_electronic_delivery
+  def on_hand_with_on_hand_of_electronic_delivery
     if electronic_delivery?
       license_key_populator.on_hand
     else
-      on_hand_without_electronic_delivery
+      on_hand_without_on_hand_of_electronic_delivery
     end
   end
-  alias_method_chain :on_hand, :electronic_delivery
+  alias_method_chain :on_hand, :on_hand_of_electronic_delivery
 
   private
   def electronic_delivery_set


### PR DESCRIPTION
I was displayed "stack level too deep" when update `spree-license-key` gem on extinguisher because it seems `alias_method_chain` overrides defined `electronic_delivery` method.