### PR TITLE
Return infinity for default populator if product has no keys

### DIFF
--- a/app/models/spree/default_license_key_populator.rb
+++ b/app/models/spree/default_license_key_populator.rb
@@ -15,6 +15,7 @@ module Spree
     end
 
     def on_hand
+      return Float::INFINITY unless variant.electronic_delivery_keys.to_i > 0
       license_key_types.map { |type| count_available(type) }.min
     end
 

--- a/spec/models/spree/default_license_key_populator_spec.rb
+++ b/spec/models/spree/default_license_key_populator_spec.rb
@@ -61,8 +61,15 @@ describe Spree::DefaultLicenseKeyPopulator do
   end
 
   describe '#on_hand' do
-    let(:variant) { create :variant }
-    let!(:license_keys) do
+    let(:electronic_delivery_keys) { 1 }
+    let(:variant) { create :variant, electronic_delivery_keys: electronic_delivery_keys, electronic_delivery: true }
+
+    context "no keys on variant" do
+      let(:electronic_delivery_keys) { 0 }
+
+      it "returns infinity" do
+        expect(populator.on_hand).to eq(Float::INFINITY)
+      end
     end
 
     context "nil license key type" do


### PR DESCRIPTION
If a variant has `electronic_delivery_keys` set to zero, then it should just return infinity for `on_hand` and always allow items to be added to the cart.