### PR TITLE
Only save electronic shipment if none existed previously

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -31,13 +31,14 @@ Spree::InventoryUnit.class_eval do
     # paraphrased from spree-core (create_units), with changes to assign
     # inventory units to electronic shipment or create new electronic shipment
     def create_electronic_units(order, variant, quantity)
+      shipment = order.shipments.electronic.first
+
       inventory_units = quantity.times.map do
-        order.inventory_units.create( { variant: variant, state: "sold" }, without_protection: true)
+        order.inventory_units.create( { variant: variant, state: "sold", shipment: shipment }, without_protection: true)
       end
 
-      shipment = order.shipments.electronic.first_or_initialize
-      shipment.inventory_units << inventory_units
-      shipment.save!
+      # create new shipment if none existed and assign inventory units
+      order.shipments.electronic.create!(inventory_units: inventory_units) if shipment.nil?
     end
   end
 end


### PR DESCRIPTION
The code currently saves the shipment every time an inventory unit is created, which triggers callbacks etc., but this is entirely unecessary unless there was no electronic shipment.

Once one electronic inventory unit has been created the shipment will be there so we don't need to keep re-saving it. This should help performance on large orders with lots of items.